### PR TITLE
Avoid duplicate sequel caller location comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/sequel_caller_location.gemspec
+++ b/sequel_caller_location.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |gem|
   gem.authors       = ['Timothée Peignier']
   gem.email         = ['timothee.peignier@tryphon.org']

--- a/spec/sequel/caller_location_spec.rb
+++ b/spec/sequel/caller_location_spec.rb
@@ -9,11 +9,21 @@ describe Sequel::CallerLocation do
     expect(ds.select_sql).to eq("SELECT * FROM t -- #{caller_locations(0, 1).first}\n")
   end
 
+  it 'add caller location to select statement only once' do
+    ds.select_sql
+    expect(ds.select_sql).to eq("SELECT * FROM t -- #{caller_locations(0, 1).first}\n")
+  end
+
   it 'add caller location to insert statement' do
     expect(ds.insert_sql(a: 1)).to eq("INSERT INTO t (a) VALUES (1) -- #{caller_locations(0, 1).first}\n")
   end
 
   it 'add caller location to delete statement' do
+    expect(ds.delete_sql).to eq("DELETE FROM t -- #{caller_locations(0, 1).first}\n")
+  end
+
+  it 'add caller location to delete statement only once' do
+    ds.delete_sql
     expect(ds.delete_sql).to eq("DELETE FROM t -- #{caller_locations(0, 1).first}\n")
   end
 


### PR DESCRIPTION
In Sequel 5 the `sql` string is persisted inside Sequel and causes that the caller location will be added.
Example:
```
$ Server.dataset.select_sql
"SELECT * FROM \"servers\" -- (pry):1:in `__binding__'\n"
$ Server.dataset.select_sql
"SELECT * FROM \"servers\" -- (pry):1:in `__binding__'\n -- (pry):2:in `__binding__'\n"
$ Server.dataset.select_sql
"SELECT * FROM \"servers\" -- (pry):1:in `__binding__'\n -- (pry):2:in `__binding__'\n -- (pry):3:in `__binding__'\n"
$ Server.dataset.select_sql
"SELECT * FROM \"servers\" -- (pry):1:in `__binding__'\n -- (pry):2:in `__binding__'\n -- (pry):3:in `__binding__'\n -- (pry):4:in `__binding__'\n"
$ Server.dataset.select_sql
"SELECT * FROM \"servers\" -- (pry):1:in `__binding__'\n -- (pry):2:in `__binding__'\n -- (pry):3:in `__binding__'\n -- (pry):4:in `__binding__'\n -- (pry):5:in `__binding__'\n"
```

I didn't find a better solution for this :(
I'm not smart enough for rubocop :(

P.S.: Greetings from the Data team and Shogun is missing you :)